### PR TITLE
-Version bump

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import java.text.SimpleDateFormat
 
 def buildVersionNameMajorMinorPatchString() {
-    return "0.1.2";
+    return "0.1.3";
 }
 
 apply plugin: 'com.android.application'

--- a/app/src/main/java/com/chrisprime/primestationonecontrol/utilities/NetworkUtilities.java
+++ b/app/src/main/java/com/chrisprime/primestationonecontrol/utilities/NetworkUtilities.java
@@ -23,13 +23,13 @@ public class NetworkUtilities {
     public static final String IP_SEPARATOR_CHAR_MATCHER = "\\.";
     public static final String IP_SEPARATOR_CHAR = ".";
     //TODO: Uncomment for full sweep!
-/*
     private static final int LAST_IP_OCTET_MIN = 1;
     private static final int LAST_IP_OCTET_MAX = 255;
-*/
     //TODO: Default to full sweep but provide user settings for last octet range
+/*
     public static final int LAST_IP_OCTET_MIN = 50;
     public static final int LAST_IP_OCTET_MAX = 55;
+*/
 
     public static DhcpInfo getDhcpInfo(Context context) {
         WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);


### PR DESCRIPTION
-Reenabled full .1 - .255 last IP octet sweep (had a smaller range for more rapid testing cycles)
